### PR TITLE
Better aural a11y

### DIFF
--- a/src/components/character-list.js
+++ b/src/components/character-list.js
@@ -6,7 +6,7 @@ export default function CharacterList(props) {
             <strong>{character.name}</strong> ({character.actor}) - {character.description}</li>
     );
     return (
-        <ul className="character-list" aria-live="polite">
+        <ul className="character-list">
             {characters}
         </ul>
     );

--- a/src/components/live-search.js
+++ b/src/components/live-search.js
@@ -19,7 +19,7 @@ export default class LiveSearch extends React.Component {
         );
         return (
             <div className="live-search">
-                <SearchForm onChange={searchTerm => this.setState({searchTerm})} />
+                <SearchForm characterCount={characters.length} onChange={searchTerm => this.setState({searchTerm})} />
                 <CharacterList characters={characters} />
             </div>
         );

--- a/src/components/search-form.js
+++ b/src/components/search-form.js
@@ -1,16 +1,17 @@
 import React from 'react';
 
 export default function SearchForm(props) {
-  const countNoun = props.characterCount === 1 ? 'result' : 'results'
+  const countText = `${props.characterCount} ${props.characterCount === 1 ? 'result' : 'results'}`;
+  
     return (
         <form onSubmit={e => e.preventDefault()}>
             <label htmlFor="search">Search</label>&emsp;
             <input type="search" id="search" name="search" placeholder="Dale Cooper" 
-                onChange={e => props.onChange(e.target.value)} />
+                onChange={e => props.onChange(e.target.value)} />&emsp;
             <span className="results-count" 
-              aria-live="assertive" 
-              aria-atomic="true">
-                {props.characterCount} {countNoun}
+                aria-live="assertive" 
+                aria-atomic="true">
+                    {countText}
               </span>
         </form>
     );

--- a/src/components/search-form.js
+++ b/src/components/search-form.js
@@ -1,11 +1,17 @@
 import React from 'react';
 
 export default function SearchForm(props) {
+  const countNoun = props.characterCount === 1 ? 'result' : 'results'
     return (
         <form onSubmit={e => e.preventDefault()}>
             <label htmlFor="search">Search</label>&emsp;
             <input type="search" id="search" name="search" placeholder="Dale Cooper" 
                 onChange={e => props.onChange(e.target.value)} />
+            <span className="results-count" 
+              aria-live="assertive" 
+              aria-atomic="true">
+                {props.characterCount} {countNoun}
+              </span>
         </form>
     );
 }

--- a/src/components/search-form.js
+++ b/src/components/search-form.js
@@ -8,10 +8,8 @@ export default function SearchForm(props) {
             <label htmlFor="search">Search</label>&emsp;
             <input type="search" id="search" name="search" placeholder="Dale Cooper" 
                 onChange={e => props.onChange(e.target.value)} />&emsp;
-            <span className="results-count" 
-                aria-live="assertive" 
-                aria-atomic="true">
-                    {countText}
+            <span className="results-count" aria-live="assertive">
+                {countText}
               </span>
         </form>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
-  /* line-height: 1.25; */
+  line-height: 1.25; 
 }
 
 .live-search {
@@ -23,5 +23,5 @@ body {
 }
 
 .character-list li {
-  margin: .25rem auto;
+  margin: .55rem auto;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,4 +2,26 @@ body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
+  /* line-height: 1.25; */
+}
+
+.live-search {
+  max-width: 1000px;
+  padding: 0 2rem;
+  margin: 3rem auto;
+}
+
+.live-search form,
+.live-search input
+.live-search span {
+  display: inline-block;
+}
+
+.live-search input {
+  font-size: inherit;
+  margin-right: 10px;
+}
+
+.character-list li {
+  margin: .25rem auto;
 }


### PR DESCRIPTION
Minor changes for a better aural ux:
- Instead of `aria-live`-ing the whole list, which gets very busy, we create a span that displays the number of results our search returns. 
- This span has `aria-live` so _it_ gets read when it changes.
  - These changes are read assertively since success/failure feedback is important
- We pass `characters.length` down to the `SearchForm` when it is rendered to make the above possible.
- Also a bit of styling for better spacing, etc

The same changes are also available on [this Glitch](https://glitch.com/edit/#!/opalescent-cabbage)

Edit: I'm not married to _this_ particular pattern. If you think it'd be better to have a results count rendered in `CharacterList` to avoid passing the same data to 2 components, feel free to veto me. Or I can make the change just as well.